### PR TITLE
fix: add missing interpolations to indexHtml ref

### DIFF
--- a/docs/documentation/pages/project-configuration/index.mdx
+++ b/docs/documentation/pages/project-configuration/index.mdx
@@ -182,16 +182,18 @@ By default we use this HTML file:
 
 ```html
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
   <head>
     <meta charset="UTF-8">
     <meta name="description" content="{{ description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{ title }}</title>
+    {{ head }}
   </head>
   <body>
     <div id="root" />
+    {{ footer }}
   </body>
 </html>
 ```


### PR DESCRIPTION
0.10.0 introduced a breaking change that requires two new interpolated variables to be added to the users index.html file if they specify one via the `indexHtml` configuration property. The documentation wasn't updated when that change was made.